### PR TITLE
added Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+sudo: required
+services:
+  - docker
+
+env:
+  DOCKER_COMPOSE_VERSION: 1.5.2
+
+before_install:
+  - sudo rm /usr/local/bin/docker-compose
+  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
+
+script:
+  - docker-compose build
+  - docker-compose up -d
+  - docker-compose ps
+  - docker-compose ps | grep Up
+  - docker-compose ps | grep "1883/tcp"
+  - docker-compose ps | grep "5672/tcp"
+  - docker-compose ps | grep "61613/tcp"
+  - docker-compose ps | grep "61614/tcp"
+  - docker-compose ps | grep "61616/tcp"
+  - docker-compose ps | grep "8161->8161"
+  # wait until ActiveMQ is available
+  - docker-compose run activemq-service wget --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 10 -O /dev/null http://admin:admin@activemq-service:8161/admin/
+  # do additional tests 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 docker-activemq
 ===============
 
+[![Build Status](https://travis-ci.org/muenchhausen/docker-activemq.svg?branch=master)](https://travis-ci.org/muenchhausen/docker-activemq)
 [![Docker Pulls](https://img.shields.io/docker/pulls/rmohr/activemq.svg?maxAge=2592000)](https://hub.docker.com/r/rmohr/activemq/)
 
 [Docker](https://www.docker.io/) file for trusted builds of [ActiveMQ](http://activemq.apache.org/) on https://registry.hub.docker.com/u/rmohr/activemq/.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+activemq-service:
+  image: rmohr/activemq:latest
+  environment:
+    - TZ=CEST
+  ports:
+    - "8161:8161"
+  expose:
+    - 8161


### PR DESCRIPTION
I was adding Travis tests to our small siemens/tstomp library. Some of the tests could be easily taken over to rmohr/docker-activemq. If you merge this pull request, please update https://travis-ci.org/muenchhausen/docker-activemq.svg in README.md to your account.
