### PR TITLE
Openshift v3.9.14 Compliant version of the 5.14.5 Apache MQ Docker File

### DIFF
--- a/5.14.5-openshift-v3.9.14/Dockerfile
+++ b/5.14.5-openshift-v3.9.14/Dockerfile
@@ -16,4 +16,4 @@ RUN chgrp -R 0 /app && \
 
 EXPOSE $ACTIVEMQ_TCP $ACTIVEMQ_AMQP $ACTIVEMQ_STOMP $ACTIVEMQ_MQTT $ACTIVEMQ_WS $ACTIVEMQ_UI
 
-CMD ["/bin/sh", "-c", "echo 'hello kambiz'; pwd; ls -al; cd apache-activemq-5.14.5/bin; ls -al; ./activemq console  "]
+CMD ["/bin/sh", "-c", "echo 'Openshift v3.9.14 Compliant ApacheMQ Image'; pwd; ls -al; cd apache-activemq-5.14.5/bin; ls -al; ./activemq console  "]

--- a/5.14.5-openshift-v3.9.14/Dockerfile
+++ b/5.14.5-openshift-v3.9.14/Dockerfile
@@ -1,0 +1,19 @@
+FROM openjdk:8-jre
+
+ENV ACTIVEMQ_VERSION 5.14.5
+ENV ACTIVEMQ apache-activemq-$ACTIVEMQ_VERSION
+ENV ACTIVEMQ_TCP=61616 ACTIVEMQ_AMQP=5672 ACTIVEMQ_STOMP=61613 ACTIVEMQ_MQTT=1883 ACTIVEMQ_WS=61614 ACTIVEMQ_UI=8161
+
+ENV ACTIVEMQ_HOME /app/apache-activemq-5.14.5
+
+WORKDIR /app
+
+RUN set -x && \
+    curl -s -S https://archive.apache.org/dist/activemq/$ACTIVEMQ_VERSION/$ACTIVEMQ-bin.tar.gz | tar xvz -C /app 
+
+RUN chgrp -R 0 /app && \
+    chmod -R g=u /app
+
+EXPOSE $ACTIVEMQ_TCP $ACTIVEMQ_AMQP $ACTIVEMQ_STOMP $ACTIVEMQ_MQTT $ACTIVEMQ_WS $ACTIVEMQ_UI
+
+CMD ["/bin/sh", "-c", "echo 'hello kambiz'; pwd; ls -al; cd apache-activemq-5.14.5/bin; ls -al; ./activemq console  "]


### PR DESCRIPTION
**Description of Change**
I have made the changes to the docker file in order to make it compliant with the above version of Openshift.
I have tested this on a Starter Openshift cluster.

The significance of this Docker file is that it does not require root privs. to run on a cluster where admin rights are not available; the latter is the norm for Openshift clusters and I have confirmed this with RedHat.
Significantly also, there is no requirement to map to an existing (/opt) directory of the underlying container.

**Outstanding Changes or Issues (that will be corrected):**
I have further modifications to make to the Docker file:
1. Adding the sha51 verification
2. Furthermore and separately I will add the K8s (oc CLI and yaml input files) later on for persistence Volumes for the apache MQ persistence requirements so to avoid the existing "ephermal" nature of the image persistence usage.
3. Finally, if the image is deployed on Openshift, it will warn that the image requires root access.
This is a false positive as the image runs fine.