### PR TITLE
Improved documentation about persistent storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,35 @@ Port Map
 
 Customizing configuration and persistence location
 --------------------------------------------------
+By default data and configuration is stored inside the container and will be
+lost after the container has been shut down and removed. To persist these
+files you can mount these directories to directories on your host system:
 
-ActiveMQ checks your environment for the variables *ACTIVEMQ_BASE*, *ACTIVEMQ_CONF* and *ACTIVEMQ_DATA*.
-Just override them with your desired location:
+    docker run -p 61616:61616 -p 8161:8161 \
+               -v /your/persistent/dir/conf:/opt/activemq/conf \
+               -v /your/persistent/dir/data:/opt/activemq/data \
+               rmohr/activemq
 
-    docker run -p 61616:61616 -p 8161:8161 -e ACTIVEMQ_CONF=/etc/activemq/conf -e ACTIVEMQ_DATA=/var/lib/activemq/data rmohr/activemq
+ActiveMQ expects that some configuration files already exists, so they won't be
+created automatically, instead you have to create them on your own before
+starting the container. If you want to start with the default configuration you
+can initialize your directories using some intermediate container:
 
-As an alternative you can just mount your persistent config and data directories into the default location:
+    docker run --user root --rm -ti \
+      -v /your/persistent/dir/conf:/mnt/conf \
+      -v /your/persistent/dir/data:/mnt/data \
+      rmohr/activemq:5.15.4-alpine /bin/sh
 
-    docker run -p 61616:61616 -p 8161:8161 -v /opt/activemq/conf:/opt/activemq/conf -v /opt/activemq/data:/opt/activemq/data rmohr/activemq
+This will bring up a shell, so you can just execute the following commands
+inside this intermediate container to copy the default configuration to your
+host directory:
+
+    chown activemq:activemq /mnt/conf
+    chown activemq:activemq /mnt/data
+    cp -a /opt/activemq/conf/* /mnt/conf/
+    cp -a /opt/activemq/data/* /mnt/data/
+    exit
+
+The last command will stop and remove the intermediate container. Your
+directories are now initialized and you can run ActiveMQ as described above.
+


### PR DESCRIPTION
The README was a little bit confusing to me. I don't see the reason why someone
should change the config and data directories inside the docker container and
thus I don't see the reason why the first example suggests to do that:

    docker run -p 61616:61616 -p 8161:8161 -e ACTIVEMQ_CONF=/etc/activemq/conf -e ACTIVEMQ_DATA=/var/lib/activemq/data rmohr/activemq

The activemq instance searches for these directories (e.g.
`/etc/activemq/conf`) _inside_ the docker container, so even if you want to use
these directories you have to create them before — inside the container (which
you cannot do as long as you don't change the entrypoint or the `Dockerfile`
itself). If you don't create these directories, docker won't start up.
Long story short: The example line does not work and ends with an exception.

Furthermore, if you are such an advanced user who changes this location, you'll
most likely want to bind these directories, so that you don't loose your data.
But if you bind these directories, you could simply bind them to the default
directories `/opt/activemq/conf` and `/opt/activemq/data` — which is the second
example.

But there is also an issue with the second example: If you bind them to two
newly created directories, docker won't start up too, because the directories
are empty and especially the `conf` directory does not contain any
configuration:

    java.io.FileNotFoundException: class path resource [activemq.xml] cannot be opened because it does not exist

So I removed these examples and improved the documentation so that it gives
some hints how to initialize persistent directories.