### PR TITLE
Implemented simple healthcheck

### DIFF
--- a/5.15.9/Dockerfile
+++ b/5.15.9/Dockerfile
@@ -29,3 +29,17 @@ WORKDIR $ACTIVEMQ_HOME
 EXPOSE $ACTIVEMQ_TCP $ACTIVEMQ_AMQP $ACTIVEMQ_STOMP $ACTIVEMQ_MQTT $ACTIVEMQ_WS $ACTIVEMQ_UI
 
 CMD ["/bin/sh", "-c", "bin/activemq console"]
+
+HEALTHCHECK --interval=1s \
+            --start-period=10s \
+            CMD ( \
+                    curl \
+                        --user admin:admin \
+                        --silent \
+                        --show-error \
+                        "http://localhost:8161/api/jolokia/exec/org.apache.activemq:type=Broker,brokerName=localhost,service=Health/healthStatus" \
+                    # copy output to fd3 (grep will consume fd1)
+                    | tee /dev/fd/3 \
+                    | grep --silent 'Good' \
+                # show curl output, from fd3
+                ) 3>&1


### PR DESCRIPTION
I have implemented simple healthcheck. In current activemq it gives the container unhealthy status though
```
$ docker inspect <containerName>
...
            "Health": {
                "Status": "unhealthy",
                "FailingStreak": 5,
                "Log": [
                    {
                        "Start": "2019-10-02T11:22:28.3457026Z",
                        "End": "2019-10-02T11:22:28.5358184Z",
                        "ExitCode": 1,
                        "Output": "{\"request\":{\"mbean\":\"org.apache.activemq:brokerName=localhost,service=Health,type=Broker\",\"type\":\"exec\",\"operation\":\"healthStatus\"},\"value\":\"Getting Worried {org.apache.activemq.FreeDiskSpaceLeft: WARNING Store limit is 45995 mb, whilst the data directory: \\/opt\\/activemq\\/data\\/kahadb only has 45994 mb of usable space from KahaDBPersistenceAdapter[\\/opt\\/activemq\\/data\\/kahadb,Index:\\/opt\\/activemq\\/data\\/kahadb] ,  }\",\"timestamp\":1570015348,\"status\":200}"
                    },
...
```
Adding `VOLUME ["/opt/activemq/data" ]` did not help.

Maybe someone can contribute and solve this. This healthcheck works for our activemq installation...

I have tried to add it to `5.15.9-alpine` version but it does not have `curl` installed. I suggest to solve the store limit issue and then the healthcheck can be implemented to other versions.