### PR TITLE
bump activemq version up to 5.15.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,8 @@ env:
       - AMQ_VERSION=5.15.6-alpine
       - AMQ_VERSION=5.15.9
       - AMQ_VERSION=5.15.9-alpine
+      - AMQ_VERSION=5.15.13
+      - AMQ_VERSION=5.15.13-alpine
 
 before_install:
   # upgrade docker-compose

--- a/5.15.13-alpine/Dockerfile
+++ b/5.15.13-alpine/Dockerfile
@@ -1,0 +1,35 @@
+FROM openjdk:8-jre-alpine
+
+ENV ACTIVEMQ_VERSION 5.15.13
+ENV ACTIVEMQ apache-activemq-$ACTIVEMQ_VERSION
+ENV ACTIVEMQ_TCP=61616 ACTIVEMQ_AMQP=5672 ACTIVEMQ_STOMP=61613 ACTIVEMQ_MQTT=1883 ACTIVEMQ_WS=61614 ACTIVEMQ_UI=8161
+ENV SHA512_VAL=4a237fe2d3cdfbc1b5b45c92a5aab0d009acbfe5383c188b9691100e2e47de0548a1c24e0d8382a88c4600cd2b8792ce75e9be7d88de55f86b0bde7c9a92c285
+
+ENV ACTIVEMQ_HOME /opt/activemq
+
+RUN set -x && \
+    mkdir -p /opt && \
+    apk --update add --virtual build-dependencies curl && \
+    curl https://archive.apache.org/dist/activemq/$ACTIVEMQ_VERSION/$ACTIVEMQ-bin.tar.gz -o $ACTIVEMQ-bin.tar.gz
+
+# Validate checksum
+RUN if [ "$SHA512_VAL" != "$(sha512sum $ACTIVEMQ-bin.tar.gz | awk '{print($1)}')" ];\
+    then \
+        echo "sha512 values doesn't match! exiting."  && \
+        exit 1; \
+    fi;
+
+RUN tar xzf $ACTIVEMQ-bin.tar.gz -C  /opt && \
+    ln -s /opt/$ACTIVEMQ $ACTIVEMQ_HOME && \
+    addgroup -S activemq && adduser -S -H -G activemq -h $ACTIVEMQ_HOME activemq && \
+    chown -R activemq:activemq /opt/$ACTIVEMQ && \
+    chown -h activemq:activemq $ACTIVEMQ_HOME && \
+    apk del build-dependencies && \
+    rm -rf /var/cache/apk/*
+
+USER activemq
+
+WORKDIR $ACTIVEMQ_HOME
+EXPOSE $ACTIVEMQ_TCP $ACTIVEMQ_AMQP $ACTIVEMQ_STOMP $ACTIVEMQ_MQTT $ACTIVEMQ_WS $ACTIVEMQ_UI
+
+CMD ["/bin/sh", "-c", "bin/activemq console"]

--- a/5.15.13/Dockerfile
+++ b/5.15.13/Dockerfile
@@ -1,0 +1,31 @@
+FROM openjdk:8-jre
+
+ENV ACTIVEMQ_VERSION 5.15.13
+ENV ACTIVEMQ apache-activemq-$ACTIVEMQ_VERSION
+ENV ACTIVEMQ_TCP=61616 ACTIVEMQ_AMQP=5672 ACTIVEMQ_STOMP=61613 ACTIVEMQ_MQTT=1883 ACTIVEMQ_WS=61614 ACTIVEMQ_UI=8161
+ENV SHA512_VAL=4a237fe2d3cdfbc1b5b45c92a5aab0d009acbfe5383c188b9691100e2e47de0548a1c24e0d8382a88c4600cd2b8792ce75e9be7d88de55f86b0bde7c9a92c285
+
+ENV ACTIVEMQ_HOME /opt/activemq
+
+
+RUN curl "https://archive.apache.org/dist/activemq/$ACTIVEMQ_VERSION/$ACTIVEMQ-bin.tar.gz" -o $ACTIVEMQ-bin.tar.gz
+
+# Validate checksum
+RUN if [ "$SHA512_VAL" != "$(sha512sum $ACTIVEMQ-bin.tar.gz | awk '{print($1)}')" ];\
+    then \
+        echo "sha512 values doesn't match! exiting."  && \
+        exit 1; \
+    fi;
+
+RUN tar xzf $ACTIVEMQ-bin.tar.gz -C  /opt && \
+    ln -s /opt/$ACTIVEMQ $ACTIVEMQ_HOME && \
+    useradd -r -M -d $ACTIVEMQ_HOME activemq && \
+    chown -R activemq:activemq /opt/$ACTIVEMQ && \
+    chown -h activemq:activemq $ACTIVEMQ_HOME 
+
+USER activemq
+
+WORKDIR $ACTIVEMQ_HOME
+EXPOSE $ACTIVEMQ_TCP $ACTIVEMQ_AMQP $ACTIVEMQ_STOMP $ACTIVEMQ_MQTT $ACTIVEMQ_WS $ACTIVEMQ_UI
+
+CMD ["/bin/sh", "-c", "bin/activemq console"]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The JMX broker listens on port 61616 and the Web Console on port 8161.
 Image Tags
 ----------
 
-    rmohr/activemq:latest (rmohr/activemq:5.15.9)
+    rmohr/activemq:latest (rmohr/activemq:5.15.13)
     rmohr/activemq:5.10.0
     rmohr/activemq:5.10.1
     rmohr/activemq:5.10.2
@@ -54,6 +54,8 @@ Image Tags
     rmohr/activemq:5.15.6-alpine
     rmohr/activemq:5.15.9
     rmohr/activemq:5.15.9-alpine
+    rmohr/activemq:5.15.13
+    rmohr/activemq:5.15.13-alpine
 
 Port Map
 --------


### PR DESCRIPTION
Hello,

Took inspiration from other accepted pull requests bumping the version up to the latest and tried to comply as much as possible.
If any corrections are required to get this merged and the latest activemq version exposed on dockerhub please let me know

cheers!